### PR TITLE
Update Artifactory and disable event and integration services

### DIFF
--- a/artifactory/Chart.yaml
+++ b/artifactory/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.0
 
 dependencies:
   - name: artifactory-oss
-    version: 107.55.14 # App version 7.55.14 when this was chosen
+    version: 107.71.3 # App version 7.71.3 when this was chosen
     repository: https://charts.jfrog.io

--- a/artifactory/values.yaml
+++ b/artifactory/values.yaml
@@ -19,6 +19,10 @@ artifactory-oss: # This is needed because we end up parenting the "artifactory-o
         postgresqlPassword: artifactoryDBpass1! # Been oddly awkward trying to hide this but the DB is internal anyway so ... maybe look at Backstage app config for a secrets-based option?
           # TODO: There is actually also the "postgresql-postgres-password" which I guess is the admin account's password, which may still cycle? Eep. `NQjjpSb5N` might have been it at some point ..
           # TODO: Needs to be moved to a secrets manager and rotated. Not a big danger, Postgres is not exposed  .. see also https://github.com/jfrog/charts/issues/859
+      event:
+        enabled: false
+      integration:
+        enabled: false
       nginx:
         enabled: false
       ingress:


### PR DESCRIPTION
This upgrades Artifactory to version `7.71.3`. The initial launch may take longer than usual post-upgrade.

It also disables the event and integration services, since they were consistently failing to start. The intention with this is to try and make Artifactory much more stable, since these components were blocking application start-up. According to https://jfrog.com/help/r/artifactory-s-microservices-explained, they shouldn't affect any of the functionality that we're using.