### PR TITLE
Add kaniko-precached-jdk17 agent

### DIFF
--- a/jenkins/templates/jenkins-agent-CM.yaml
+++ b/jenkins/templates/jenkins-agent-CM.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jenkins-agent-cm
+data:
+  jenkins-agent: |-
+    #!/usr/bin/env sh
+    # The MIT License
+    #
+    #  Copyright (c) 2015, CloudBees, Inc.
+    #
+    #  Permission is hereby granted, free of charge, to any person obtaining a copy
+    #  of this software and associated documentation files (the "Software"), to deal
+    #  in the Software without restriction, including without limitation the rights
+    #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    #  copies of the Software, and to permit persons to whom the Software is
+    #  furnished to do so, subject to the following conditions:
+    #
+    #  The above copyright notice and this permission notice shall be included in
+    #  all copies or substantial portions of the Software.
+    #
+    #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    #  THE SOFTWARE.
+
+    # Usage jenkins-slave.sh [options] -url http://jenkins [SECRET] [AGENT_NAME]
+    # Optional environment variables :
+    # * JENKINS_TUNNEL : HOST:PORT for a tunnel to route TCP traffic to jenkins host, when jenkins can't be directly accessed over network
+    # * JENKINS_URL : alternate jenkins URL
+    # * JENKINS_SECRET : agent secret, if not set as an argument
+    # * JENKINS_AGENT_NAME : agent name, if not set as an argument
+    # * JENKINS_AGENT_WORKDIR : agent work directory, if not set by optional parameter -workDir
+    # * JENKINS_WEB_SOCKET: true if the connection should be made via WebSocket rather than TCP
+    # * JENKINS_DIRECT_CONNECTION: Connect directly to this TCP agent port, skipping the HTTP(S) connection parameter download.
+    #                              Value: "<HOST>:<PORT>"
+    # * JENKINS_INSTANCE_IDENTITY: The base64 encoded InstanceIdentity byte array of the Jenkins master. When this is set,
+    #                              the agent skips connecting to an HTTP(S) port for connection info.
+    # * JENKINS_PROTOCOLS:         Specify the remoting protocols to attempt when instanceIdentity is provided.
+
+      if [ $# -eq 1 ]; then
+
+      # if `docker run` only has one arguments, we assume user is running alternate command like `bash` to inspect the image
+      exec "$@"
+
+      else
+
+      # if -tunnel is not provided try env vars
+      case "$@" in
+      *"-tunnel "*) ;;
+      *)
+      if [ ! -z "$JENKINS_TUNNEL" ]; then
+      TUNNEL="-tunnel $JENKINS_TUNNEL"
+      fi ;;
+      esac
+
+      # if -workDir is not provided, try env vars
+      if [ ! -z "$JENKINS_AGENT_WORKDIR" ]; then
+      case "$@" in
+      *"-workDir"*) echo "Warning: Work directory is defined twice in command-line arguments and the environment variable" ;;
+      *)
+      WORKDIR="-workDir $JENKINS_AGENT_WORKDIR" ;;
+      esac
+      fi
+
+      if [ -n "$JENKINS_URL" ]; then
+      URL="-url $JENKINS_URL"
+      fi
+
+      if [ -n "$JENKINS_NAME" ]; then
+      JENKINS_AGENT_NAME="$JENKINS_NAME"
+      fi
+
+      if [ "$JENKINS_WEB_SOCKET" = true ]; then
+      WEB_SOCKET=-webSocket
+      fi
+
+      if [ -n "$JENKINS_PROTOCOLS" ]; then
+      PROTOCOLS="-protocols $JENKINS_PROTOCOLS"
+      fi
+
+      if [ -n "$JENKINS_DIRECT_CONNECTION" ]; then
+      DIRECT="-direct $JENKINS_DIRECT_CONNECTION"
+      fi
+
+      if [ -n "$JENKINS_INSTANCE_IDENTITY" ]; then
+      INSTANCE_IDENTITY="-instanceIdentity $JENKINS_INSTANCE_IDENTITY"
+      fi
+
+      if [ -z "$JNLP_PROTOCOL_OPTS" ]; then
+    echo "Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior"
+      JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
+      fi
+
+      # If both required options are defined, do not pass the parameters
+      OPT_JENKINS_SECRET=""
+      if [ -n "$JENKINS_SECRET" ]; then
+      case "$@" in
+      *"${JENKINS_SECRET}"*) echo "Warning: SECRET is defined twice in command-line arguments and the environment variable" ;;
+      *)
+      OPT_JENKINS_SECRET="${JENKINS_SECRET}" ;;
+      esac
+      fi
+
+      OPT_JENKINS_AGENT_NAME=""
+      if [ -n "$JENKINS_AGENT_NAME" ]; then
+      case "$@" in
+      *"${JENKINS_AGENT_NAME}"*) echo "Warning: AGENT_NAME is defined twice in command-line arguments and the environment variable" ;;
+      *)
+      OPT_JENKINS_AGENT_NAME="${JENKINS_AGENT_NAME}" ;;
+      esac
+      fi
+
+      SLAVE_JAR=/usr/share/jenkins/slave.jar
+      if [ ! -f "$SLAVE_JAR" ]; then
+      tmpfile=$(mktemp)
+      if hash wget > /dev/null 2>&1; then
+      wget -O "$tmpfile" "$JENKINS_URL/jnlpJars/slave.jar"
+      elif hash curl > /dev/null 2>&1; then
+      curl -o "$tmpfile" "$JENKINS_URL/jnlpJars/slave.jar"
+      else
+      echo "Image does not include $SLAVE_JAR and could not find wget or curl to download it"
+      return 1
+      fi
+      SLAVE_JAR=$tmpfile
+      fi
+
+      #TODO: Handle the case when the command-line and Environment variable contain different values.
+      #It is fine it blows up for now since it should lead to an error anyway.
+
+      exec java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp $SLAVE_JAR hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+      fi
+

--- a/jenkins/values-agents.yaml
+++ b/jenkins/values-agents.yaml
@@ -5,13 +5,19 @@ jenkins:
     # Note that an additional "terajenkins-jenkins-agent" label gets added everywhere (podLabels thing?)
     customJenkinsLabels: "kaniko-precached-jdk11 ts-engine ts-module lib heavy light java11 light-java"
     nodeUsageMode: "EXCLUSIVE"
-    sideContainerName: builder
+    sideContainerName: jnlp
     image: terasology/jenkins-precached-agent
     tag: latest-jdk11
-    command: "/bin/sh -c"
-    args: "cat"
+    command: "/bin/sh"
+    args: "/var/jenkins_config/jenkins-agent"
     # This is needed for some reason or the controller refuses to connect this agent?
     TTYEnabled: true
+    volumes:
+      # Mount the agent start script into the container
+      - type: ConfigMap
+        configMapName: jenkins-agent-cm
+        mountPath: /var/jenkins_config/jenkins-agent
+        subPath: jenkins-agent
     # Set resources for additional agents to inherit
     resources:
       requests:
@@ -29,7 +35,7 @@ jenkins:
 
     kanikoSeventeen:
       podName: kaniko-precached-jdk17
-      customJenkinsLabels: "kaniko-precached-jdk17 java17"
+      customJenkinsLabels: "kaniko-precached-jdk17 ts-engine ts-module heavy java17"
       tag: latest-jdk17
 
     javaNative:

--- a/jenkins/values-agents.yaml
+++ b/jenkins/values-agents.yaml
@@ -27,6 +27,11 @@ jenkins:
       customJenkinsLabels: "kaniko-precached-jdk8"
       tag: latest-jdk8
 
+    kanikoSeventeen:
+      podName: kaniko-precached-jdk17
+      customJenkinsLabels: "kaniko-precached-jdk17 java17"
+      tag: latest-jdk17
+
     javaNative:
       podName: java-native
       customJenkinsLabels: "java-native"


### PR DESCRIPTION
This adds a JDK 17 builder agent to Jenkins so that Terasology can be built under Java 17.

This soft-depends on MovingBlocks/JenkinsAgentPrecachedJava#4. You may have to push the initial image manually however until Java 17 support is merged into Terasology's `develop`.

The `jenkins-agent-CM` configmap was taken from https://github.com/MovingBlocks/JenkinsAgentPrecachedJava/blob/main/jenkins-agent-CM.yaml.