### PR TITLE
fix: disable cli (CVE-2024-23897)

### DIFF
--- a/jenkins/values.yaml
+++ b/jenkins/values.yaml
@@ -23,6 +23,21 @@ jenkins:
     numExecutors: 1
     executorMode: EXCLUSIVE
     customJenkinsLabels: "main"
+    initScripts:
+      disableCli: |-
+        def removal = { lst ->
+          lst.each { x -> if (x.getClass().name?.contains("CLIAction")) lst.remove(x) }
+        }
+        def j = jenkins.model.Jenkins.get();
+        removal(j.getExtensionList(hudson.cli.CLIAction.class))
+        removal(j.getExtensionList(hudson.ExtensionPoint.class))
+        removal(j.getExtensionList(hudson.model.Action.class))
+        removal(j.getExtensionList(hudson.model.ModelObject.class))
+        removal(j.getExtensionList(hudson.model.RootAction.class))
+        removal(j.getExtensionList(hudson.model.UnprotectedRootAction.class))
+        removal(j.getExtensionList(java.lang.Object.class))
+        removal(j.getExtensionList(org.kohsuke.stapler.StaplerProxy.class))
+        removal(j.actions)
 
     # Pull secrets from Kubernetes and set them as env vars on the pod for JCasC to use later
     containerEnv:


### PR DESCRIPTION
Adds init script acting as init hook that disables CLI by removing the CLI HTTP endpoint. See [mitigation instructions](https://github.com/jenkinsci-cert/SECURITY-3314-3315/?tab=readme-ov-file) for [CVE-2024-23897](https://nvd.nist.gov/vuln/detail/CVE-2024-23897)